### PR TITLE
Use https:// to specify source instead of git://

### DIFF
--- a/gonapps-jwt-1.0-1.rockspec
+++ b/gonapps-jwt-1.0-1.rockspec
@@ -2,7 +2,7 @@ package = "gonapps-jwt"
 version = "1.0-1"
 
 source = {
-    url = "git://github.com/gonapps/gonapps-lua-jwt",
+    url = "https://github.com/gonapps/gonapps-lua-jwt",
     tag = "v1.0"
 }
 


### PR DESCRIPTION
Some (corporate) environments might not allow users to reach the git protocol port on the Internet causing the `git clone` step to block and timeout finally. Switching to https fixes that as most (corporate) environments allow https to pass through.